### PR TITLE
fix: adjust the necessary esbuild peer dependency version

### DIFF
--- a/esbuild-node-externals/README.md
+++ b/esbuild-node-externals/README.md
@@ -9,7 +9,7 @@ When bundling with Esbuild for the backend by default it will try to bundle all 
 
 ## Installation
 
-This plugin requires minimum **Node.js 12**, and **Esbuild 0.8+**.
+This plugin requires minimum **Node.js 12**, and **Esbuild 0.12+**.
 
 ```sh
 # with npm

--- a/esbuild-node-externals/package.json
+++ b/esbuild-node-externals/package.json
@@ -21,7 +21,7 @@
     "src"
   ],
   "peerDependencies": {
-    "esbuild": "^0.13.0"
+    "esbuild": "0.12 - 0.14"
   },
   "devDependencies": {
     "@types/node": "16.11.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -242,7 +242,7 @@ __metadata:
     tslib: 2.3.1
     typescript: 4.4.4
   peerDependencies:
-    esbuild: ^0.13.0
+    esbuild: 0.12 - 0.14
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Additionally allow esbuild versions up to 0.14.

fixes: #26 