### PR TITLE
feat: allow esbuild 0.15

### DIFF
--- a/esbuild-node-externals/package.json
+++ b/esbuild-node-externals/package.json
@@ -21,7 +21,7 @@
     "src"
   ],
   "peerDependencies": {
-    "esbuild": "0.12 - 0.14"
+    "esbuild": "0.12 - 0.15"
   },
   "devDependencies": {
     "@types/node": "16.11.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -242,7 +242,7 @@ __metadata:
     tslib: 2.3.1
     typescript: 4.4.4
   peerDependencies:
-    esbuild: 0.12 - 0.14
+    esbuild: 0.12 - 0.15
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Increases peer dependency range to include esbuild 0.15.

Closes #31 