### PR TITLE
feat: add flag to support workspaces dependencies

### DIFF
--- a/esbuild-node-externals/README.md
+++ b/esbuild-node-externals/README.md
@@ -82,6 +82,10 @@ Make package.json `optionalDependencies` external.
 
 Specify packages which are not marked as external. They will be included in the bundle.
 
+#### `options.allowWorkspaces` (default to `false`)
+
+Automatically exclude all packages defined as workspaces (`workspace:*`) in a monorepo.
+
 ## Inspiration
 
 This package and the implementation are inspired by the work of @liady on [webpack-node-externals](https://github.com/liady/webpack-node-externals) for webpack and @Septh on [rollup-plugin-node-externals](https://github.com/Septh/rollup-plugin-node-externals) for rollup.

--- a/esbuild-node-externals/src/index.ts
+++ b/esbuild-node-externals/src/index.ts
@@ -9,6 +9,7 @@ export interface Options {
   peerDependencies?: boolean;
   optionalDependencies?: boolean;
   allowList?: string[];
+  allowWorkspaces?: boolean;
 }
 
 export const nodeExternalsPlugin = (paramsOptions: Options = {}): Plugin => {
@@ -18,6 +19,7 @@ export const nodeExternalsPlugin = (paramsOptions: Options = {}): Plugin => {
     peerDependencies: true,
     optionalDependencies: true,
     allowList: [] as string[],
+    allowWorkspaces: false,
     ...paramsOptions,
     packagePath:
       paramsOptions.packagePath && typeof paramsOptions.packagePath === 'string'
@@ -34,6 +36,7 @@ export const nodeExternalsPlugin = (paramsOptions: Options = {}): Plugin => {
     peerDependencies: options.peerDependencies,
     optionalDependencies: options.optionalDependencies,
     allowList: options.allowList,
+    allowWorkspaces: options.allowWorkspaces,
   });
 
   return {


### PR DESCRIPTION
This adds support for yarn workspaces to this plugin, under the "allowWorkspaces" option.

More context here: https://github.com/evanw/esbuild/issues/3060