### PR TITLE
feat: handle esbuild `absWorkingDir` option

### DIFF
--- a/esbuild-node-externals/README.md
+++ b/esbuild-node-externals/README.md
@@ -86,6 +86,10 @@ An array for the externals to allow, so they will be included in the bundle. Can
 
 Automatically exclude all packages defined as workspaces (`workspace:*`) in a monorepo.
 
+#### `options.cwd` (default to `buildOptions.absWorkingDir || process.cwd()`)
+
+Sets the current working directory for the plugin.
+
 ## Inspiration
 
 This package and the implementation are inspired by the work of @liady on [webpack-node-externals](https://github.com/liady/webpack-node-externals) for webpack and @Septh on [rollup-plugin-node-externals](https://github.com/Septh/rollup-plugin-node-externals) for rollup.

--- a/esbuild-node-externals/src/utils.ts
+++ b/esbuild-node-externals/src/utils.ts
@@ -34,15 +34,16 @@ const isInGitDirectory = (path: string, gitRootPath?: string): boolean => {
  * files outside of the git repository will not be yielded.
  * Inspired by https://github.com/Septh/rollup-plugin-node-externals/blob/f13ee95c6f1f01d8ba2276bf491aac399adc5482/src/dependencies.ts#L18
  */
-export const findPackagePaths = (): string[] => {
+export const findPackagePaths = (_cwd: string = process.cwd()): string[] => {
   // Find git root if in git repository
   const gitDirectoryPath = findUp.sync('.git', {
     type: 'directory',
+    cwd: _cwd,
   });
   const gitRootPath: string | undefined =
     gitDirectoryPath === undefined ? undefined : path.dirname(gitDirectoryPath);
 
-  let cwd: string = process.cwd();
+  let cwd: string = _cwd;
   let packagePath: string | undefined;
   const packagePaths: string[] = [];
 


### PR DESCRIPTION
This PR:
* introduces a new plugin option `cwd`
* sets its default value to `build.initialOptions.absWorkingDir || process.cwd()` if not specified.