### PR TITLE
feat: add esbuild 0.23.0 to allowed range

### DIFF
--- a/esbuild-node-externals/package.json
+++ b/esbuild-node-externals/package.json
@@ -10,7 +10,7 @@
     "watch": "tsc --watch",
     "test": "node ./test/unit/index.test.mjs"
   },
-  "repository": "https://github.com/pradel/esbuild-node-externals.git",
+  "repository": "pradel/esbuild-node-externals",
   "author": "Leo Pradel <pradel.leo@gmail.com>",
   "license": "MIT",
   "keywords": [
@@ -31,11 +31,11 @@
     "tslib": "^2.4.1"
   },
   "peerDependencies": {
-    "esbuild": "0.12 - 0.21"
+    "esbuild": "0.12 - 0.23"
   },
   "devDependencies": {
     "@types/node": "^18.15.10",
-    "esbuild": "^0.21.0",
+    "esbuild": "^0.23.0",
     "rimraf": "^4.4.1",
     "typescript": "^4.9.4"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -34,9 +34,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/aix-ppc64@npm:0.21.0":
-  version: 0.21.0
-  resolution: "@esbuild/aix-ppc64@npm:0.21.0"
+"@esbuild/aix-ppc64@npm:0.23.0":
+  version: 0.23.0
+  resolution: "@esbuild/aix-ppc64@npm:0.23.0"
   conditions: os=aix & cpu=ppc64
   languageName: node
   linkType: hard
@@ -48,9 +48,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/android-arm64@npm:0.21.0":
-  version: 0.21.0
-  resolution: "@esbuild/android-arm64@npm:0.21.0"
+"@esbuild/android-arm64@npm:0.23.0":
+  version: 0.23.0
+  resolution: "@esbuild/android-arm64@npm:0.23.0"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
@@ -62,9 +62,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/android-arm@npm:0.21.0":
-  version: 0.21.0
-  resolution: "@esbuild/android-arm@npm:0.21.0"
+"@esbuild/android-arm@npm:0.23.0":
+  version: 0.23.0
+  resolution: "@esbuild/android-arm@npm:0.23.0"
   conditions: os=android & cpu=arm
   languageName: node
   linkType: hard
@@ -76,9 +76,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/android-x64@npm:0.21.0":
-  version: 0.21.0
-  resolution: "@esbuild/android-x64@npm:0.21.0"
+"@esbuild/android-x64@npm:0.23.0":
+  version: 0.23.0
+  resolution: "@esbuild/android-x64@npm:0.23.0"
   conditions: os=android & cpu=x64
   languageName: node
   linkType: hard
@@ -90,9 +90,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/darwin-arm64@npm:0.21.0":
-  version: 0.21.0
-  resolution: "@esbuild/darwin-arm64@npm:0.21.0"
+"@esbuild/darwin-arm64@npm:0.23.0":
+  version: 0.23.0
+  resolution: "@esbuild/darwin-arm64@npm:0.23.0"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
@@ -104,9 +104,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/darwin-x64@npm:0.21.0":
-  version: 0.21.0
-  resolution: "@esbuild/darwin-x64@npm:0.21.0"
+"@esbuild/darwin-x64@npm:0.23.0":
+  version: 0.23.0
+  resolution: "@esbuild/darwin-x64@npm:0.23.0"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
@@ -118,9 +118,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/freebsd-arm64@npm:0.21.0":
-  version: 0.21.0
-  resolution: "@esbuild/freebsd-arm64@npm:0.21.0"
+"@esbuild/freebsd-arm64@npm:0.23.0":
+  version: 0.23.0
+  resolution: "@esbuild/freebsd-arm64@npm:0.23.0"
   conditions: os=freebsd & cpu=arm64
   languageName: node
   linkType: hard
@@ -132,9 +132,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/freebsd-x64@npm:0.21.0":
-  version: 0.21.0
-  resolution: "@esbuild/freebsd-x64@npm:0.21.0"
+"@esbuild/freebsd-x64@npm:0.23.0":
+  version: 0.23.0
+  resolution: "@esbuild/freebsd-x64@npm:0.23.0"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
@@ -146,9 +146,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/linux-arm64@npm:0.21.0":
-  version: 0.21.0
-  resolution: "@esbuild/linux-arm64@npm:0.21.0"
+"@esbuild/linux-arm64@npm:0.23.0":
+  version: 0.23.0
+  resolution: "@esbuild/linux-arm64@npm:0.23.0"
   conditions: os=linux & cpu=arm64
   languageName: node
   linkType: hard
@@ -160,9 +160,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/linux-arm@npm:0.21.0":
-  version: 0.21.0
-  resolution: "@esbuild/linux-arm@npm:0.21.0"
+"@esbuild/linux-arm@npm:0.23.0":
+  version: 0.23.0
+  resolution: "@esbuild/linux-arm@npm:0.23.0"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
@@ -174,9 +174,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/linux-ia32@npm:0.21.0":
-  version: 0.21.0
-  resolution: "@esbuild/linux-ia32@npm:0.21.0"
+"@esbuild/linux-ia32@npm:0.23.0":
+  version: 0.23.0
+  resolution: "@esbuild/linux-ia32@npm:0.23.0"
   conditions: os=linux & cpu=ia32
   languageName: node
   linkType: hard
@@ -188,9 +188,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/linux-loong64@npm:0.21.0":
-  version: 0.21.0
-  resolution: "@esbuild/linux-loong64@npm:0.21.0"
+"@esbuild/linux-loong64@npm:0.23.0":
+  version: 0.23.0
+  resolution: "@esbuild/linux-loong64@npm:0.23.0"
   conditions: os=linux & cpu=loong64
   languageName: node
   linkType: hard
@@ -202,9 +202,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/linux-mips64el@npm:0.21.0":
-  version: 0.21.0
-  resolution: "@esbuild/linux-mips64el@npm:0.21.0"
+"@esbuild/linux-mips64el@npm:0.23.0":
+  version: 0.23.0
+  resolution: "@esbuild/linux-mips64el@npm:0.23.0"
   conditions: os=linux & cpu=mips64el
   languageName: node
   linkType: hard
@@ -216,9 +216,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/linux-ppc64@npm:0.21.0":
-  version: 0.21.0
-  resolution: "@esbuild/linux-ppc64@npm:0.21.0"
+"@esbuild/linux-ppc64@npm:0.23.0":
+  version: 0.23.0
+  resolution: "@esbuild/linux-ppc64@npm:0.23.0"
   conditions: os=linux & cpu=ppc64
   languageName: node
   linkType: hard
@@ -230,9 +230,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/linux-riscv64@npm:0.21.0":
-  version: 0.21.0
-  resolution: "@esbuild/linux-riscv64@npm:0.21.0"
+"@esbuild/linux-riscv64@npm:0.23.0":
+  version: 0.23.0
+  resolution: "@esbuild/linux-riscv64@npm:0.23.0"
   conditions: os=linux & cpu=riscv64
   languageName: node
   linkType: hard
@@ -244,9 +244,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/linux-s390x@npm:0.21.0":
-  version: 0.21.0
-  resolution: "@esbuild/linux-s390x@npm:0.21.0"
+"@esbuild/linux-s390x@npm:0.23.0":
+  version: 0.23.0
+  resolution: "@esbuild/linux-s390x@npm:0.23.0"
   conditions: os=linux & cpu=s390x
   languageName: node
   linkType: hard
@@ -258,9 +258,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/linux-x64@npm:0.21.0":
-  version: 0.21.0
-  resolution: "@esbuild/linux-x64@npm:0.21.0"
+"@esbuild/linux-x64@npm:0.23.0":
+  version: 0.23.0
+  resolution: "@esbuild/linux-x64@npm:0.23.0"
   conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
@@ -272,10 +272,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/netbsd-x64@npm:0.21.0":
-  version: 0.21.0
-  resolution: "@esbuild/netbsd-x64@npm:0.21.0"
+"@esbuild/netbsd-x64@npm:0.23.0":
+  version: 0.23.0
+  resolution: "@esbuild/netbsd-x64@npm:0.23.0"
   conditions: os=netbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openbsd-arm64@npm:0.23.0":
+  version: 0.23.0
+  resolution: "@esbuild/openbsd-arm64@npm:0.23.0"
+  conditions: os=openbsd & cpu=arm64
   languageName: node
   linkType: hard
 
@@ -286,9 +293,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/openbsd-x64@npm:0.21.0":
-  version: 0.21.0
-  resolution: "@esbuild/openbsd-x64@npm:0.21.0"
+"@esbuild/openbsd-x64@npm:0.23.0":
+  version: 0.23.0
+  resolution: "@esbuild/openbsd-x64@npm:0.23.0"
   conditions: os=openbsd & cpu=x64
   languageName: node
   linkType: hard
@@ -300,9 +307,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/sunos-x64@npm:0.21.0":
-  version: 0.21.0
-  resolution: "@esbuild/sunos-x64@npm:0.21.0"
+"@esbuild/sunos-x64@npm:0.23.0":
+  version: 0.23.0
+  resolution: "@esbuild/sunos-x64@npm:0.23.0"
   conditions: os=sunos & cpu=x64
   languageName: node
   linkType: hard
@@ -314,9 +321,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/win32-arm64@npm:0.21.0":
-  version: 0.21.0
-  resolution: "@esbuild/win32-arm64@npm:0.21.0"
+"@esbuild/win32-arm64@npm:0.23.0":
+  version: 0.23.0
+  resolution: "@esbuild/win32-arm64@npm:0.23.0"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
@@ -328,9 +335,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/win32-ia32@npm:0.21.0":
-  version: 0.21.0
-  resolution: "@esbuild/win32-ia32@npm:0.21.0"
+"@esbuild/win32-ia32@npm:0.23.0":
+  version: 0.23.0
+  resolution: "@esbuild/win32-ia32@npm:0.23.0"
   conditions: os=win32 & cpu=ia32
   languageName: node
   linkType: hard
@@ -342,9 +349,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/win32-x64@npm:0.21.0":
-  version: 0.21.0
-  resolution: "@esbuild/win32-x64@npm:0.21.0"
+"@esbuild/win32-x64@npm:0.23.0":
+  version: 0.23.0
+  resolution: "@esbuild/win32-x64@npm:0.23.0"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -493,13 +500,13 @@ __metadata:
   resolution: "esbuild-node-externals@workspace:esbuild-node-externals"
   dependencies:
     "@types/node": ^18.15.10
-    esbuild: ^0.21.0
+    esbuild: ^0.23.0
     find-up: ^5.0.0
     rimraf: ^4.4.1
     tslib: ^2.4.1
     typescript: ^4.9.4
   peerDependencies:
-    esbuild: 0.12 - 0.21
+    esbuild: 0.12 - 0.23
   languageName: unknown
   linkType: soft
 
@@ -583,33 +590,34 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild@npm:^0.21.0":
-  version: 0.21.0
-  resolution: "esbuild@npm:0.21.0"
+"esbuild@npm:^0.23.0":
+  version: 0.23.0
+  resolution: "esbuild@npm:0.23.0"
   dependencies:
-    "@esbuild/aix-ppc64": 0.21.0
-    "@esbuild/android-arm": 0.21.0
-    "@esbuild/android-arm64": 0.21.0
-    "@esbuild/android-x64": 0.21.0
-    "@esbuild/darwin-arm64": 0.21.0
-    "@esbuild/darwin-x64": 0.21.0
-    "@esbuild/freebsd-arm64": 0.21.0
-    "@esbuild/freebsd-x64": 0.21.0
-    "@esbuild/linux-arm": 0.21.0
-    "@esbuild/linux-arm64": 0.21.0
-    "@esbuild/linux-ia32": 0.21.0
-    "@esbuild/linux-loong64": 0.21.0
-    "@esbuild/linux-mips64el": 0.21.0
-    "@esbuild/linux-ppc64": 0.21.0
-    "@esbuild/linux-riscv64": 0.21.0
-    "@esbuild/linux-s390x": 0.21.0
-    "@esbuild/linux-x64": 0.21.0
-    "@esbuild/netbsd-x64": 0.21.0
-    "@esbuild/openbsd-x64": 0.21.0
-    "@esbuild/sunos-x64": 0.21.0
-    "@esbuild/win32-arm64": 0.21.0
-    "@esbuild/win32-ia32": 0.21.0
-    "@esbuild/win32-x64": 0.21.0
+    "@esbuild/aix-ppc64": 0.23.0
+    "@esbuild/android-arm": 0.23.0
+    "@esbuild/android-arm64": 0.23.0
+    "@esbuild/android-x64": 0.23.0
+    "@esbuild/darwin-arm64": 0.23.0
+    "@esbuild/darwin-x64": 0.23.0
+    "@esbuild/freebsd-arm64": 0.23.0
+    "@esbuild/freebsd-x64": 0.23.0
+    "@esbuild/linux-arm": 0.23.0
+    "@esbuild/linux-arm64": 0.23.0
+    "@esbuild/linux-ia32": 0.23.0
+    "@esbuild/linux-loong64": 0.23.0
+    "@esbuild/linux-mips64el": 0.23.0
+    "@esbuild/linux-ppc64": 0.23.0
+    "@esbuild/linux-riscv64": 0.23.0
+    "@esbuild/linux-s390x": 0.23.0
+    "@esbuild/linux-x64": 0.23.0
+    "@esbuild/netbsd-x64": 0.23.0
+    "@esbuild/openbsd-arm64": 0.23.0
+    "@esbuild/openbsd-x64": 0.23.0
+    "@esbuild/sunos-x64": 0.23.0
+    "@esbuild/win32-arm64": 0.23.0
+    "@esbuild/win32-ia32": 0.23.0
+    "@esbuild/win32-x64": 0.23.0
   dependenciesMeta:
     "@esbuild/aix-ppc64":
       optional: true
@@ -647,6 +655,8 @@ __metadata:
       optional: true
     "@esbuild/netbsd-x64":
       optional: true
+    "@esbuild/openbsd-arm64":
+      optional: true
     "@esbuild/openbsd-x64":
       optional: true
     "@esbuild/sunos-x64":
@@ -659,7 +669,7 @@ __metadata:
       optional: true
   bin:
     esbuild: bin/esbuild
-  checksum: 90cc4b7a82f25e42d3df6021c2178ea193889e6c73dae8a384573625340dbe67370412ea4d9ac1ecd90c7bbeeca5cc32f6be22e8313bafcb73792f5b8b118cc2
+  checksum: 22138538225d5ce79f84fc0d3d3e31b57a91ef50ef00f2d6a9c8a4be4ed28d4b1d0ed14239e54341d1b9a7079f25e69761d0266f3c255da94e647b079b790421
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
* Extend esbuild compat range to v0.23.0
* Change pkg.json repo link format to display on https://www.npmjs.com/package/esbuild-node-externals