### PR TITLE
feat: add `forceExternalList` option

### DIFF
--- a/esbuild-node-externals/README.md
+++ b/esbuild-node-externals/README.md
@@ -82,6 +82,10 @@ Make package.json `optionalDependencies` external.
 
 An array for the externals to allow, so they will be included in the bundle. Can accept exact strings ('module_name'), regex patterns (/^module_name/), or a function that accepts the module name and returns whether it should be included.
 
+#### `options.forceExternalList` (default to `[]`)
+
+An array that forces packages to be treated as external, even if not in `package.json`, so they will be excluded from the bundle. Can accept exact strings ('module_name'), regex patterns (/^module_name/), or a function that accepts the module name and returns whether it should be externalized.
+
 #### `options.allowWorkspaces` (default to `false`)
 
 Automatically exclude all packages defined as workspaces (`workspace:*`) in a monorepo.

--- a/esbuild-node-externals/src/index.ts
+++ b/esbuild-node-externals/src/index.ts
@@ -14,6 +14,7 @@ export interface Options {
   peerDependencies?: boolean;
   optionalDependencies?: boolean;
   allowList?: AllowList;
+  forceExternalList?: AllowList;
   allowWorkspaces?: boolean;
   cwd?: string;
 }
@@ -44,7 +45,8 @@ export const nodeExternalsPlugin = (paramsOptions: Options = {}): Plugin => {
 
   const allowPredicate =
     options.allowList && createAllowPredicate(options.allowList);
-
+  const externalPredicate =
+    options.forceExternalList && createAllowPredicate(options.forceExternalList);
 
   return {
     name: 'node-externals',
@@ -79,6 +81,11 @@ export const nodeExternalsPlugin = (paramsOptions: Options = {}): Plugin => {
 
         // Mark the module as external so it is not resolved
         if (nodeModules.includes(moduleName)) {
+          return { path: args.path, external: true };
+        }
+
+        // Allow one last override to force a path/package to be treated as external
+        if (externalPredicate?.(args.path)) {
           return { path: args.path, external: true };
         }
 


### PR DESCRIPTION
The [Rolllup equivalent plugin](https://www.npmjs.com/package/rollup-plugin-node-externals) has both `include` and `exclude` functions --- confusingly named, but functional:

| purpose | `rollup-plugin-node-externals` | `esbuild-node-externals` |
| -------- | ----------------------------- | ----------------------- |
| exclude from externalization (include in bundle) | `exclude` option | `allowList` option |
| force treating as external (exclude from bundle) | `include` option | ??? |

I'm proposing `forceExternalList` to fill the missing space in this plugin, patch included.

This is helpful for externalizing dependencies of dependencies --- packages I need externalized, but that aren't listed directly in my `package.json` file.